### PR TITLE
FIX: unusedvars & react-navigation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,12 @@
 module.exports = {
   root: true,
   extends: '@react-native-community',
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      rules: {
+        '@typescript-eslint/no-unused-vars': 0,
+      },
+    },
+  ],
 };

--- a/app/navigation/NavigationService.tsx
+++ b/app/navigation/NavigationService.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { NavigationContainerRef } from '@react-navigation/native';
+import { createNavigationContainerRef } from '@react-navigation/native';
 
 // NavigationContainer is referred here - Check NavigationStack
-export const navigationRef = React.createRef<NavigationContainerRef>();
+export const navigationRef = createNavigationContainerRef();
 
 function navigate(name: string, params?: any) {
-  navigationRef.current?.navigate(name, params);
+  navigationRef.current?.navigate({ key: name, params });
 }
 
 function goBack() {

--- a/app/navigation/NavigationStack.tsx
+++ b/app/navigation/NavigationStack.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { NavigationContainer, Theme } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import {
+  createStackNavigator,
+  StackNavigationOptions,
+} from '@react-navigation/stack';
 import { useSelector } from 'react-redux';
 
 import { navigationRef } from './NavigationService';
@@ -17,7 +20,7 @@ const Stack = createStackNavigator();
 const AuthStack = createStackNavigator();
 const LoggedInStack = createStackNavigator();
 
-const homeOptions = {
+const homeOptions: StackNavigationOptions = {
   title: 'Home',
   headerTitleStyle: {
     fontWeight: 'bold',
@@ -79,7 +82,7 @@ const App: React.FC<IProps> = (props: IProps) => {
     <NavigationContainer ref={navigationRef} theme={theme}>
       <StatusBar barStyle={theme.dark ? 'light-content' : 'dark-content'} />
 
-      <Stack.Navigator headerMode="none">
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
         {isLoggedIn ? (
           <Stack.Screen
             name="Home"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,8 +30,8 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 


### PR DESCRIPTION
Implemented small fix for unused-vars eslint rule. Was incorrectly working with imported typescript types. Disabled the rule and instead turned ON noUnusedLocals and noUnusedParameters.
As for react-navigation - adopted options and types as per new docs and same for Navigation ref